### PR TITLE
Add microseconds to timestamps

### DIFF
--- a/ApplicationInsights/Channel/Contracts/Utils.php
+++ b/ApplicationInsights/Channel/Contracts/Utils.php
@@ -80,17 +80,18 @@ class Utils
     /**
      * Returns the proper ISO string for Application Insights service to accept.
      *
-     * @param float|int|null $time
+     * @param null|float|int $time
      *
      * @return string
      */
     public static function returnISOStringForTime($time = null)
     {
         if ($time == null) {
-            $time = microtime(true);
+            $time = \microtime(true);
         }
 
-        $datetime = \DateTime::createFromFormat('U.u', number_format($time, 6, '.', ''));
+        $datetime = \DateTime::createFromFormat('U.u', \number_format($time, 6, '.', ''));
+
         return $datetime->format("Y-m-d\TH:i:s.u") . 'Z';
     }
 

--- a/ApplicationInsights/Channel/Contracts/Utils.php
+++ b/ApplicationInsights/Channel/Contracts/Utils.php
@@ -80,17 +80,18 @@ class Utils
     /**
      * Returns the proper ISO string for Application Insights service to accept.
      *
-     * @param mixed $time
+     * @param float|int|null $time
      *
      * @return string
      */
     public static function returnISOStringForTime($time = null)
     {
         if ($time == null) {
-            return \gmdate('c') . 'Z';
+            $time = microtime(true);
         }
 
-        return \gmdate('c', $time) . 'Z';
+        $datetime = \DateTime::createFromFormat('U.u', number_format($time, 6, '.', ''));
+        return $datetime->format("Y-m-d\TH:i:s.u") . 'Z';
     }
 
     /**

--- a/ApplicationInsights/Telemetry_Client.php
+++ b/ApplicationInsights/Telemetry_Client.php
@@ -160,7 +160,7 @@ class Telemetry_Client
      *
      * @param string $name a friendly name of the request
      * @param string $url the url of the request
-     * @param int $startTime the timestamp at which the request started
+     * @param float|int $startTime the timestamp at which the request started
      * @param int $durationInMilliseconds the duration, in milliseconds, of the request
      * @param int $httpResponseCode the response code of the request
      * @param bool $isSuccessful whether or not the request was successful
@@ -177,7 +177,7 @@ class Telemetry_Client
      *
      * @param string $name a friendly name of the request
      * @param string $url the url of the request
-     * @param int $startTime the timestamp at which the request started
+     * @param float|int $startTime the timestamp at which the request started
      *
      * @return \ApplicationInsights\Channel\Contracts\Request_Data an initialized Request_Data, which can be sent by using @see endRequest
      */
@@ -289,7 +289,7 @@ class Telemetry_Client
      * @param string $name name of the dependency
      * @param string $type the Dependency type of value being sent
      * @param string $commandName command/Method of the dependency
-     * @param int $startTime the timestamp at which the request started
+     * @param float|int $startTime the timestamp at which the request started
      * @param int $durationInMilliseconds the duration, in milliseconds, of the request
      * @param bool $isSuccessful whether or not the request was successful
      * @param int $resultCode the result code of the request

--- a/Tests/Channel/Contracts/Utils_Test.php
+++ b/Tests/Channel/Contracts/Utils_Test.php
@@ -40,13 +40,11 @@ class Utils_Test extends TestCase
         $this->assertEquals('1970-01-01T00:00:01.000100Z', Utils::returnISOStringForTime(1.0001));
         $this->assertEquals('1970-01-01T00:00:01.000010Z', Utils::returnISOStringForTime(1.00001));
         $this->assertEquals('1970-01-01T00:00:01.000001Z', Utils::returnISOStringForTime(1.000001));
-
         $this->assertEquals('1970-01-01T00:00:01.000000Z', Utils::returnISOStringForTime(1.0000001), 'truncate to 6 decimal places');
         $this->assertEquals('1970-01-01T00:00:00.999999Z', Utils::returnISOStringForTime(0.999999));
         $this->assertEquals('1970-01-01T00:00:00.999999Z', Utils::returnISOStringForTime(0.9999994), 'rounds down to 6 decimal places');
         $this->assertEquals('1970-01-01T00:00:00.999999Z', Utils::returnISOStringForTime(0.9999985), 'rounds up to 6 decimal places');
         $this->assertEquals('1970-01-01T00:00:01.000000Z', Utils::returnISOStringForTime(0.9999995), 'rounds up to 6 decimal places');
-        
         $this->assertEquals('1970-01-01T00:00:11.123456Z', Utils::returnISOStringForTime(11.123456));
         $this->assertEquals('2023-10-05T17:49:53.000000Z', Utils::returnISOStringForTime(1696528193));
         $this->assertEquals('2023-10-05T17:49:53.999999Z', Utils::returnISOStringForTime(1696528193.999999));
@@ -57,13 +55,13 @@ class Utils_Test extends TestCase
         // Make sure that the current time is used if null is passed in.
         // We can't know exactly what microtime() will return, so instead we'll just make sure that
         // the returned time is within 1 second of the current time.
-        
-        $curTime = microtime(true);
-        $time = Utils::returnISOStringForTime();
-        $this->assertTrue(strtotime($time) < $curTime + 1.0, "Failed when time=$time and $curTime=$curTime");
 
-        $curTime = microtime(true);
+        $curTime = \microtime(true);
+        $time = Utils::returnISOStringForTime();
+        $this->assertTrue(\strtotime($time) < $curTime + 1.0, "Failed when time={$time} and {$curTime}={$curTime}");
+
+        $curTime = \microtime(true);
         $time = Utils::returnISOStringForTime(null);
-        $this->assertTrue(strtotime($time) < $curTime + 1.0, "Failed when time=$time and $curTime=$curTime");
+        $this->assertTrue(\strtotime($time) < $curTime + 1.0, "Failed when time={$time} and {$curTime}={$curTime}");
     }
 }

--- a/Tests/Channel/Contracts/Utils_Test.php
+++ b/Tests/Channel/Contracts/Utils_Test.php
@@ -29,4 +29,41 @@ class Utils_Test extends TestCase
         $this->assertEquals(Utils::convertMillisecondsToTimeSpan([]), '00:00:00.000', 'invalid input');
         $this->assertEquals(Utils::convertMillisecondsToTimeSpan(-1), '00:00:00.000', 'invalid input');
     }
+
+    public function testReturnISOStringForTime() : void
+    {
+        $this->assertEquals('1970-01-01T00:00:01.000000Z', Utils::returnISOStringForTime(1));
+        $this->assertEquals('1970-01-01T00:00:01.000000Z', Utils::returnISOStringForTime(1.000000));
+        $this->assertEquals('1970-01-01T00:00:01.100000Z', Utils::returnISOStringForTime(1.1));
+        $this->assertEquals('1970-01-01T00:00:01.010000Z', Utils::returnISOStringForTime(1.01));
+        $this->assertEquals('1970-01-01T00:00:01.001000Z', Utils::returnISOStringForTime(1.001));
+        $this->assertEquals('1970-01-01T00:00:01.000100Z', Utils::returnISOStringForTime(1.0001));
+        $this->assertEquals('1970-01-01T00:00:01.000010Z', Utils::returnISOStringForTime(1.00001));
+        $this->assertEquals('1970-01-01T00:00:01.000001Z', Utils::returnISOStringForTime(1.000001));
+
+        $this->assertEquals('1970-01-01T00:00:01.000000Z', Utils::returnISOStringForTime(1.0000001), 'truncate to 6 decimal places');
+        $this->assertEquals('1970-01-01T00:00:00.999999Z', Utils::returnISOStringForTime(0.999999));
+        $this->assertEquals('1970-01-01T00:00:00.999999Z', Utils::returnISOStringForTime(0.9999994), 'rounds down to 6 decimal places');
+        $this->assertEquals('1970-01-01T00:00:00.999999Z', Utils::returnISOStringForTime(0.9999985), 'rounds up to 6 decimal places');
+        $this->assertEquals('1970-01-01T00:00:01.000000Z', Utils::returnISOStringForTime(0.9999995), 'rounds up to 6 decimal places');
+        
+        $this->assertEquals('1970-01-01T00:00:11.123456Z', Utils::returnISOStringForTime(11.123456));
+        $this->assertEquals('2023-10-05T17:49:53.000000Z', Utils::returnISOStringForTime(1696528193));
+        $this->assertEquals('2023-10-05T17:49:53.999999Z', Utils::returnISOStringForTime(1696528193.999999));
+    }
+
+    public function testReturnISOStringForTime_nullInput() : void
+    {
+        // Make sure that the current time is used if null is passed in.
+        // We can't know exactly what microtime() will return, so instead we'll just make sure that
+        // the returned time is within 1 second of the current time.
+        
+        $curTime = microtime(true);
+        $time = Utils::returnISOStringForTime();
+        $this->assertTrue(strtotime($time) < $curTime + 1.0, "Failed when time=$time and $curTime=$curTime");
+
+        $curTime = microtime(true);
+        $time = Utils::returnISOStringForTime(null);
+        $this->assertTrue(strtotime($time) < $curTime + 1.0, "Failed when time=$time and $curTime=$curTime");
+    }
 }


### PR DESCRIPTION
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add microseconds to timestamps</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Currently all timestamps sent by the library are truncated to seconds, so millisecond and microsecond timings are discarded. This makes it much less useful when trying to debug and track events within a single HTTP request.

This is the same issue that is called out on the original repo: https://github.com/microsoft/ApplicationInsights-PHP/issues/72

I also removed the UTC offset since it's not needed since we are using UTC datetimes throughout.

|||
|-|-|
| Example current timestamp | `2023-10-05T06:03:06+00:00Z` |
| Example new timestamp | `2023-10-05T06:03:06.000000Z` |
| Example new timestamp (with microseconds) | `2023-10-05T06:03:06.123456Z` |
