### PR TITLE
Replace deprecated function utf8_encode with mb_convert_encoding.

### DIFF
--- a/ApplicationInsights/Channel/Telemetry_Channel.php
+++ b/ApplicationInsights/Channel/Telemetry_Channel.php
@@ -238,7 +238,7 @@ class Telemetry_Channel
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json; charset=utf-8',
             ];
-            $body = \utf8_encode($serializedTelemetryItem);
+            $body = mb_convert_encoding($serializedTelemetryItem, 'UTF-8');
         }
 
         if ($useGuzzle) {

--- a/ApplicationInsights/Channel/Telemetry_Channel.php
+++ b/ApplicationInsights/Channel/Telemetry_Channel.php
@@ -238,7 +238,7 @@ class Telemetry_Channel
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json; charset=utf-8',
             ];
-            $body = mb_convert_encoding($serializedTelemetryItem, 'UTF-8');
+            $body = \mb_convert_encoding($serializedTelemetryItem, 'UTF-8', 'ISO-8859-1');
         }
 
         if ($useGuzzle) {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>In php8.2 utf8_encode is deprecated, replaced with mb_convert_encoding </li> 
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->